### PR TITLE
feat: add yellow color option with estoril response

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,11 +78,11 @@ npx @miew-devsecops/test-npm-utility-package
 
 ### User Interaction
 1. Prompts user: "What's your favorite color?"
-2. Accepts input: "blue" or "red"
+2. Accepts selection: "blue", "red", or "yellow"
 3. Returns responses:
    - Blue → "FCP!"
    - Red → "SLB :/"
-   - Other → Error message
+   - Yellow → "estoril"
 
 ### Error Handling
 - Invalid color input

--- a/README.md
+++ b/README.md
@@ -4,15 +4,64 @@ A simple CLI tool that asks for your favorite color and responds accordingly.
 
 ## Usage
 
-Run the package using npx:
+### Quick Start (GitHub Packages)
+
+Since this package is published to GitHub Packages, you need to configure npm to use the GitHub registry for scoped packages:
 
 ```bash
+# Configure npm to use GitHub Packages for @miew-devsecops scope
+npm config set @miew-devsecops:registry https://npm.pkg.github.com
+
+# Run the package using npx
 npx @miew-devsecops/test-npm-utility-package
 ```
 
-The tool will prompt you to enter your favorite color. Valid responses are:
-- `blue` → Returns "FCP!"
-- `red` → Returns "SLB :/"
+### Alternative: One-time usage
+
+You can also run it directly by specifying the registry:
+
+```bash
+npx --registry https://npm.pkg.github.com @miew-devsecops/test-npm-utility-package
+```
+
+The tool will present a selector with color options:
+- Select `Blue` → Returns "FCP!"
+- Select `Red` → Returns "SLB :/"
+- Select `Yellow` → Returns "estoril"
+
+### Installing in a Project
+
+To include this package as a dependency in your project, first create or update your `.npmrc` file to configure the GitHub Packages registry:
+
+```ini
+# .npmrc
+@miew-devsecops:registry=https://npm.pkg.github.com
+```
+
+Then add it to your `package.json`:
+
+```json
+{
+  "name": "my-project",
+  "version": "1.0.0",
+  "dependencies": {
+    "@miew-devsecops/test-npm-utility-package": "^1.0.0"
+  },
+  "scripts": {
+    "color-tool": "npx @miew-devsecops/test-npm-utility-package"
+  }
+}
+```
+
+After running `npm install`, you can use it in your project:
+
+```bash
+# Run directly
+npm run color-tool
+
+# Or use npx
+npx @miew-devsecops/test-npm-utility-package
+```
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,33 @@ A simple CLI tool that asks for your favorite color and responds accordingly.
 
 ## Usage
 
+### Prerequisites
+
+Since this package is published to GitHub Packages under the `@miew-devsecops` organization, you'll need proper authentication and permissions:
+
+**Requirements:**
+- Your GitHub account must have access to the `miew-devsecops` organization
+- You need a Personal Access Token with the `read:packages` scope
+- The token must be authorized for the organization (if SSO is enabled)
+
+**Create a Personal Access Token:**
+1. Go to [GitHub Settings → Personal access tokens → Tokens (classic)](https://github.com/settings/tokens)
+2. Click "Generate new token (classic)"
+3. Give it a descriptive name (e.g., "NPM GitHub Packages")
+4. Select the `read:packages` scope (required for downloading packages)
+5. Click "Generate token"
+6. **Important**: If the organization has SSO enabled, authorize your token:
+   - After creating the token, you'll see "Configure SSO" next to it
+   - Click "Configure SSO" and authorize for `miew-devsecops`
+7. Copy the generated token
+8. Configure npm with your token:
+
+```bash
+npm config set //npm.pkg.github.com/:_authToken YOUR_TOKEN_HERE
+```
+
+Replace `YOUR_TOKEN_HERE` with the token you just created.
+
 ### Quick Start (GitHub Packages)
 
 Since this package is published to GitHub Packages, you need to configure npm to use the GitHub registry for scoped packages:
@@ -36,7 +63,10 @@ To include this package as a dependency in your project, first create or update 
 ```ini
 # .npmrc
 @miew-devsecops:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=YOUR_TOKEN_HERE
 ```
+
+**Note:** Replace `YOUR_TOKEN_HERE` with your actual PAT created in the Prerequisites section above.
 
 Then add it to your `package.json`:
 
@@ -62,6 +92,39 @@ npm run color-tool
 # Or use npx
 npx @miew-devsecops/test-npm-utility-package
 ```
+
+### Troubleshooting
+
+If you get a 403 error when trying to install the package:
+
+1. **Check organization access**: Ensure your GitHub account is a member of the `miew-devsecops` organization
+2. **Verify token scopes**: Your PAT must have `read:packages` scope
+3. **SSO Authorization**: If the organization uses SSO, make sure your token is authorized for the organization
+4. **Package visibility**: Contact the organization admin if the package isn't visible to your account
+
+Common error messages:
+- `403 Forbidden`: Usually means missing organization access or incorrect token scopes
+- `404 Not Found`: Package doesn't exist or you don't have permission to see it
+
+**Check your current token configuration:**
+
+```bash
+# View all npm config settings
+npm config list
+
+# Check specifically for GitHub Packages token
+npm config get //npm.pkg.github.com/:_authToken
+
+# View npm config file location
+npm config get userconfig
+
+# Edit npm config file directly
+npm config edit
+```
+
+**Token storage locations:**
+- **Windows**: `%USERPROFILE%\.npmrc` (e.g., `C:\Users\YourName\.npmrc`)
+- **macOS/Linux**: `~/.npmrc`
 
 ## Development
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,7 +8,8 @@ export async function runCLI(): Promise<void> {
       message: "What's your favorite color?",
       choices: [
         { name: 'Blue', value: 'blue' },
-        { name: 'Red', value: 'red' }
+        { name: 'Red', value: 'red' },
+        { name: 'Yellow', value: 'yellow' }
       ]
     }
   ]);
@@ -19,5 +20,7 @@ export async function runCLI(): Promise<void> {
     console.log('FCP!');
   } else if (color === 'red') {
     console.log('SLB :/');
+  } else if (color === 'yellow') {
+    console.log('estoril');
   }
 }


### PR DESCRIPTION
## Summary
- Added Yellow as a third color choice in the CLI selector
- Returns "estoril" when yellow is selected
- Updated documentation in README.md and CLAUDE.md to reflect new option
- Added comprehensive GitHub Packages authentication guide for organization access

## Changes Made
- Added yellow color option to CLI choices array
- Implemented "estoril" response for yellow selection
- Updated user interaction documentation
- Enhanced README with organization-specific authentication requirements
- Added troubleshooting section for common package access issues

## Test Plan
- [x] Build passes successfully
- [x] ESLint passes without errors
- [x] CLI displays three color options (Blue, Red, Yellow)
- [x] Yellow selection returns "estoril" response
- [x] Documentation updated to reflect changes